### PR TITLE
docs: add CHANGELOG.md (Keep a Changelog + SemVer 2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial scaffold — OOD compute adapter for Amazon ECS Fargate, translating Open OnDemand job lifecycle calls to the Amazon ECS API.
+- CLI commands: `submit` (JSON job spec from stdin → Fargate task, prints task ARN), `status <task-arn>` (OOD-normalized status), `delete <task-arn>` (stop a task), and `info <task-arn>` (full `DescribeTasks` response as JSON).
+- Unit and substrate integration tests.
+
+### Changed
+- Upgraded to substrate v0.45.2 and removed the local `replace` directive; earlier upgraded to v0.44.3 (fixes substrate #241 ECS timestamp bug).


### PR DESCRIPTION
Adds `CHANGELOG.md` adopting the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) + [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) convention used across the rest of the project ecosystem (`oidc-pam`, `aws-hubzero`, `substrate`, `aws-openondemand`).

This repo is pre-release (no tags yet), so all current work is recorded under `## [Unreleased]`. Entries are derived from the existing commit history and README — no code changes.